### PR TITLE
Feature: Add CLI list-templates Command  `Closes #31`

### DIFF
--- a/cli/devopsos.py
+++ b/cli/devopsos.py
@@ -877,5 +877,44 @@ def process_first_cmd(
     process_first.display(section.value)
 
 
+# List of scaffold modules for dynamic template discovery
+_SCAFFOLD_MODULES = [
+    scaffold_gha,
+    scaffold_gitlab,
+    scaffold_jenkins,
+    scaffold_cicd,
+    scaffold_argocd,
+    scaffold_sre,
+    scaffold_unittest,
+    scaffold_devcontainer,
+]
+
+
+def _collect_templates():
+    """Collect TEMPLATE_INFO from all scaffold modules, grouped by category."""
+    by_category = {}
+    for mod in _SCAFFOLD_MODULES:
+        info = getattr(mod, "TEMPLATE_INFO", None)
+        if info:
+            cat = info.get("category", "Other")
+            by_category.setdefault(cat, []).append(info)
+    return by_category
+
+
+@app.command("list")
+def list_templates():
+    """List all available scaffold templates organized by category."""
+    templates = _collect_templates()
+    typer.echo("\nAvailable Templates:\n")
+    for category, items in templates.items():
+        typer.echo(typer.style(category, bold=True))
+        for t in items:
+            name = t["name"].ljust(14)
+            desc = t["description"]
+            typer.echo(f"  {name} {desc}")
+        typer.echo()
+    typer.echo("Run 'python -m cli.devopsos scaffold --help' for usage details.\n")
+
+
 if __name__ == "__main__":
     app()

--- a/cli/devopsos.py
+++ b/cli/devopsos.py
@@ -895,8 +895,8 @@ def _collect_templates():
     by_category = {}
     for mod in _SCAFFOLD_MODULES:
         info = getattr(mod, "TEMPLATE_INFO", None)
-        if info:
-            cat = info.get("category", "Other")
+        if isinstance(info, dict):
+            cat = info.get("category") or "Other"
             by_category.setdefault(cat, []).append(info)
     return by_category
 

--- a/cli/scaffold_argocd.py
+++ b/cli/scaffold_argocd.py
@@ -16,6 +16,12 @@ Outputs:
   └── image-update-automation.yaml Flux image update automation
 """
 
+TEMPLATE_INFO = {
+    "name": "argocd",
+    "category": "GitOps",
+    "description": "ArgoCD/Flux manifests",
+}
+
 import os
 import argparse
 import yaml

--- a/cli/scaffold_cicd.py
+++ b/cli/scaffold_cicd.py
@@ -11,6 +11,12 @@ Usage:
     python -m cli.devopsos scaffold cicd [options]
 """
 
+TEMPLATE_INFO = {
+    "name": "cicd",
+    "category": "CI/CD",
+    "description": "Combined CI/CD (GHA + Jenkins)",
+}
+
 import os
 import sys
 import argparse

--- a/cli/scaffold_devcontainer.py
+++ b/cli/scaffold_devcontainer.py
@@ -13,6 +13,12 @@ Outputs (relative to --output-dir):
   └── devcontainer.env.json    Tool / language selection & versions
 """
 
+TEMPLATE_INFO = {
+    "name": "devcontainer",
+    "category": "Development",
+    "description": "VS Code dev containers",
+}
+
 import os
 import argparse
 import json

--- a/cli/scaffold_gha.py
+++ b/cli/scaffold_gha.py
@@ -15,6 +15,12 @@ Features:
 - Matrix build support for multiple OS/architectures
 """
 
+TEMPLATE_INFO = {
+    "name": "gha",
+    "category": "CI/CD",
+    "description": "GitHub Actions workflows",
+}
+
 import os
 import sys
 import argparse

--- a/cli/scaffold_gitlab.py
+++ b/cli/scaffold_gitlab.py
@@ -14,6 +14,12 @@ Features:
 - Merge request pipelines and branch protection
 """
 
+TEMPLATE_INFO = {
+    "name": "gitlab",
+    "category": "CI/CD",
+    "description": "GitLab CI pipelines",
+}
+
 import os
 import sys
 import argparse

--- a/cli/scaffold_jenkins.py
+++ b/cli/scaffold_jenkins.py
@@ -15,6 +15,12 @@ Features:
 - Support for various source control management (SCM) systems
 """
 
+TEMPLATE_INFO = {
+    "name": "jenkins",
+    "category": "CI/CD",
+    "description": "Jenkins pipelines",
+}
+
 import os
 import sys
 import argparse

--- a/cli/scaffold_sre.py
+++ b/cli/scaffold_sre.py
@@ -16,6 +16,12 @@ Outputs (default: sre/ directory):
   └── alertmanager-config.yaml Alertmanager receiver config stub
 """
 
+TEMPLATE_INFO = {
+    "name": "sre",
+    "category": "SRE",
+    "description": "Prometheus alerts, Grafana dashboards, SLOs",
+}
+
 import os
 import argparse
 import json

--- a/cli/scaffold_unittest.py
+++ b/cli/scaffold_unittest.py
@@ -26,6 +26,12 @@ Output layout (default: <output-dir>/ in the current directory):
   └── sample_test.go          # Go — sample unit test file
 """
 
+TEMPLATE_INFO = {
+    "name": "unittest",
+    "category": "Testing",
+    "description": "Unit test configs (pytest, Jest, Go)",
+}
+
 import os
 import sys
 import argparse

--- a/cli/test_cli.py
+++ b/cli/test_cli.py
@@ -24,6 +24,28 @@ def _strip_ansi(s):
 
 # -- devopsos CLI ----------------------------------------------------------
 
+def test_list_command():
+    """Test that list command shows all templates grouped by category."""
+    result = _run_module("cli.devopsos", ["list"])
+    assert result.returncode == 0
+    out = _strip_ansi(result.stdout)
+    assert "CI/CD" in out
+    assert "GitOps" in out
+    assert "SRE" in out
+    assert "Testing" in out
+    assert "Development" in out
+    assert "gha" in out
+    assert "jenkins" in out
+    assert "argocd" in out
+
+
+def test_list_in_help():
+    """Test that list appears in main help."""
+    result = _run_module("cli.devopsos", ["--help"])
+    assert result.returncode == 0
+    assert "list" in result.stdout
+
+
 def test_help():
     result = _run(["-m", "cli.devopsos", "--help"])
     assert result.returncode == 0


### PR DESCRIPTION
Adds new Feature: Add CLI list-templates Command #31


## Description
Add a new `list` command to the CLI that displays all available scaffold templates organized by category. This enables users to discover available templates without consulting documentation.

## Related Issue
Closes #31

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🔧 Refactor / code cleanup
- [ ] 🧪 Test improvement

## Changes Made
- Added `TEMPLATE_INFO` dictionary to 8 scaffold modules for dynamic discovery
- Added `_collect_templates()` helper function in `devopsos.py`
- Added `@app.command("list")` command to display templates by category
- Added tests for the new `list` command

## Testing Done
- [x] Existing tests pass (`python -m pytest cli/test_cli.py mcp_server/test_server.py tests/test_comprehensive.py -v`)
- [x] New tests added to cover the changes
- [x] Manually tested: `python -m cli.devopsos list`

## Checklist
- [x] My code follows the existing style and conventions
- [x] I have self-reviewed my code
- [x] My changes do not introduce new warnings or errors
- [x] I have linked the related issue above
- [x] All CI checks are passing
